### PR TITLE
Add annotations to MARK

### DIFF
--- a/de.fraunhofer.aisec.mark.parent/de.fraunhofer.aisec.mark/src/de/fraunhofer/aisec/mark/MarkDsl.xtext
+++ b/de.fraunhofer.aisec.mark.parent/de.fraunhofer.aisec.mark/src/de/fraunhofer/aisec/mark/MarkDsl.xtext
@@ -9,7 +9,7 @@ generate markDsl "http://www.aisec.fraunhofer.de/mark/MarkDsl"
 MarkModel:
     package=PackageDeclaration
     /* either an entity or a rule, multiple per file and in arbitrary order */
-    ( decl+=EntityDeclaration | rule+=RuleDeclaration )+
+    ( decl+=EntityDeclaration | annotations+=AnnotationDeclaration | rule+=RuleDeclaration )+
 ;
 
 
@@ -27,7 +27,7 @@ PackageDeclaration:
  */
 
 EntityDeclaration:
-    'entity' name=DotQualifiedIdentifier ( 'isa' superType=[EntityDeclaration|DotQualifiedIdentifier] )? '{' content+=EntityStatement* '}'
+    (annotations+=Annotation)* 'entity' name=DotQualifiedIdentifier ( 'isa' superType=[EntityDeclaration|DotQualifiedIdentifier] )? '{' content+=EntityStatement* '}'
 ;
 
 EntityStatement:
@@ -96,7 +96,7 @@ Template:
  */
 
 RuleDeclaration:
-	'rule' name=ID '{' stmt=RuleStatement '}'
+	(annotations+=Annotation)* 'rule' name=ID '{' stmt=RuleStatement '}'
 ;
 
 RuleStatement:
@@ -243,6 +243,26 @@ GroupingExpression returns OrderExpression:
 
 
 /**
+ * Annotations
+ */
+
+AnnotationDeclaration:
+	'annotation' name=ID '{' fields+=AnnotationField* '}'
+;
+
+AnnotationField:
+	'var' name=ID (':' type=MType)? ('=' default=(Literal|LiteralListExpression))? ';'
+;
+
+Annotation:
+	'@' name=[AnnotationDeclaration] ('(' args+=AnnotationArgument (',' args+=AnnotationArgument)* ')')?
+;
+
+AnnotationArgument:
+	(field=ID '=')? value=(Literal | LiteralListExpression)
+;
+
+/**
  * Common rule(s)
  * 
  * Rules that are used by multiple other rules
@@ -266,6 +286,13 @@ CppQualifiedName:
     ID ('::' ID)+ 
 ;
 
+
+/**
+ * MARK types
+ */
+enum MType:
+	BOOL='bool' | NUMERIC='numeric' | STRING='string' | LIST='list'
+;
 
 /**
  * Literal(s)

--- a/examples/annotations.mark
+++ b/examples/annotations.mark
@@ -1,0 +1,30 @@
+package test
+
+annotation T1 {}
+
+
+annotation T2 {
+	var v1;
+	var v2 = 1;
+	var v3 = [1, 2, 3];
+	var v4 : string;
+}
+
+
+@T1
+entity E1 {
+	var v1;
+	
+	op init {
+		init(v1);
+	}
+}
+
+@T1
+@T2(1, v4="test")
+rule R1 {
+	using E1 as e
+	ensure
+		e.v1 > 5
+	fail
+}


### PR DESCRIPTION
We want some kind of meta level to group and reason about entities and rules. One use case we currently solve with comments is the tracking of rules for specific standards and guidelines. This is somewhat cumbersome.

We add a meta language layer comparable to Java's annotation feature. Annotated entities and rules could now be queried by their annotations. This allows to reason about the set of all rules with a common annotation. Additionally, this would allow to define new evaluation rules based on annotations. E.g. some generic requirement is fulfilled if some or all rules with a given annotation are evaluated positively.

An example is included in this PR.