### PR TITLE
Add annotation feature to MARK

### DIFF
--- a/de.fraunhofer.aisec.mark.parent/de.fraunhofer.aisec.mark/src/de/fraunhofer/aisec/mark/MarkDsl.xtext
+++ b/de.fraunhofer.aisec.mark.parent/de.fraunhofer.aisec.mark/src/de/fraunhofer/aisec/mark/MarkDsl.xtext
@@ -251,7 +251,7 @@ AnnotationDeclaration:
 ;
 
 AnnotationField:
-	'var' name=ID (':' type=MType)? ('=' default=(Literal|LiteralListExpression))? ';'
+	'var' name=ID ':' ('=' default=(Literal|LiteralListExpression))? ';'
 ;
 
 Annotation:
@@ -290,9 +290,9 @@ CppQualifiedName:
 /**
  * MARK types
  */
-enum MType:
-	BOOL='bool' | NUMERIC='numeric' | STRING='string' | LIST='list'
-;
+//enum MType:
+//	BOOL='bool' | NUMERIC='numeric' | STR='string' | LIST='list'
+//;
 
 /**
  * Literal(s)

--- a/de.fraunhofer.aisec.mark/src/de/fraunhofer/aisec/mark/MarkDsl.xtext
+++ b/de.fraunhofer.aisec.mark/src/de/fraunhofer/aisec/mark/MarkDsl.xtext
@@ -243,6 +243,26 @@ GroupingExpression returns OrderExpression:
 
 
 /**
+ * Annotations
+ */
+
+AnnotationDeclaration:
+	'annotation' name=ID '{' fields+=AnnotationField* '}'
+;
+
+AnnotationField:
+	'var' name=ID ':' ('=' default=(Literal|LiteralListExpression))? ';'
+;
+
+Annotation:
+	'@' name=[AnnotationDeclaration] ('(' args+=AnnotationArgument (',' args+=AnnotationArgument)* ')')?
+;
+
+AnnotationArgument:
+	(field=ID '=')? value=(Literal | LiteralListExpression)
+;
+
+/**
  * Common rule(s)
  * 
  * Rules that are used by multiple other rules
@@ -266,6 +286,13 @@ CppQualifiedName:
     ID ('::' ID)+ 
 ;
 
+
+/**
+ * MARK types
+ */
+//enum MType:
+//	BOOL='bool' | NUMERIC='numeric' | STR='string' | LIST='list'
+//;
 
 /**
  * Literal(s)

--- a/de.fraunhofer.aisec.mark/src/de/fraunhofer/aisec/mark/MarkDsl.xtext
+++ b/de.fraunhofer.aisec.mark/src/de/fraunhofer/aisec/mark/MarkDsl.xtext
@@ -9,7 +9,7 @@ generate markDsl "http://www.aisec.fraunhofer.de/mark/MarkDsl"
 MarkModel:
     package=PackageDeclaration
     /* either an entity or a rule, multiple per file and in arbitrary order */
-    ( decl+=EntityDeclaration | rule+=RuleDeclaration )+
+    ( decl+=EntityDeclaration | annotations+=AnnotationDeclaration | rule+=RuleDeclaration )+
 ;
 
 
@@ -27,7 +27,7 @@ PackageDeclaration:
  */
 
 EntityDeclaration:
-    'entity' name=DotQualifiedIdentifier ( 'isa' superType=[EntityDeclaration|DotQualifiedIdentifier] )? '{' content+=EntityStatement* '}'
+    (annotations+=Annotation)* 'entity' name=DotQualifiedIdentifier ( 'isa' superType=[EntityDeclaration|DotQualifiedIdentifier] )? '{' content+=EntityStatement* '}'
 ;
 
 EntityStatement:
@@ -96,7 +96,7 @@ Template:
  */
 
 RuleDeclaration:
-	'rule' name=ID '{' stmt=RuleStatement '}'
+	(annotations+=Annotation)* 'rule' name=ID '{' stmt=RuleStatement '}'
 ;
 
 RuleStatement:


### PR DESCRIPTION
We add annotations to the MARK language. Annotations are comparabel to those in Java.

We defined a new structure `annotation` to define a name and fields of an annotation. Afterwards, an `entity` and `rule` declarations can be labelled with an annotation. The label usese `@Name`.  Values for fields can be provided using paranthesis and a comma separated value list.