### PR TITLE
Remove obsolete left-over colon

### DIFF
--- a/de.fraunhofer.aisec.mark/src/de/fraunhofer/aisec/mark/MarkDsl.xtext
+++ b/de.fraunhofer.aisec.mark/src/de/fraunhofer/aisec/mark/MarkDsl.xtext
@@ -251,7 +251,7 @@ AnnotationDeclaration:
 ;
 
 AnnotationField:
-	'var' name=ID ':' ('=' default=(Literal|LiteralListExpression))? ';'
+	'var' name=ID ('=' default=(Literal|LiteralListExpression))? ';'
 ;
 
 Annotation:


### PR DESCRIPTION
A colon was overseen when introducing the annotation feature to MARK.