### PR TITLE
Make MARK file content more optional

### DIFF
--- a/de.fraunhofer.aisec.mark/src/de/fraunhofer/aisec/mark/MarkDsl.xtext
+++ b/de.fraunhofer.aisec.mark/src/de/fraunhofer/aisec/mark/MarkDsl.xtext
@@ -9,7 +9,7 @@ generate markDsl "http://www.aisec.fraunhofer.de/mark/MarkDsl"
 MarkModel:
     package=PackageDeclaration
     /* either an entity or a rule, multiple per file and in arbitrary order */
-    ( decl+=EntityDeclaration | annotations+=AnnotationDeclaration | rule+=RuleDeclaration )+
+    ( decl+=EntityDeclaration | annotations+=AnnotationDeclaration | rule+=RuleDeclaration )*
 ;
 
 


### PR DESCRIPTION
We usually require that a MARK file contains at least an entity or a rule. However, there are cases where we comment out rules because they are very use case dependent. This causes parsing errors in MARK.

We change the minimal structure of MARK files to now require only a `package` declaration.